### PR TITLE
fix: include dist/index.js in npm tarball

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@ scripts
 .gitignore
 .prettierrc
 index.js
+!dist/index.js
 index.test.js
 index.types-test.tsx
 jest.config.js


### PR DESCRIPTION
Fixes #214

We could also fix it by using relative file paths for the files in root, whatever you prefer :) 